### PR TITLE
Use shared resource for attributes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "dsc-style-bundle"]
 	path = dsc-style-bundle
 	url = git@github.com:SUSEdoc/dsc-style-bundle.git
+[submodule "product-docs-common"]
+	path = product-docs-common
+	url = https://github.com/rancher/product-docs-common

--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -31,6 +31,9 @@ antora:
       script_stem: header-scripts # <3>
       mermaid_initialize_options: # <4>
         start_on_load: true
+    - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
+      attributefile: ./product-docs-common/global-attributes.yml
+      enabled: true
 
 output:
   dir: build/site

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -34,6 +34,9 @@ antora:
     script_stem: header-scripts # <3>
     mermaid_initialize_options: # <4>
       start_on_load: true
+  - require: ./product-docs-common/extensions/dynamic-loading-attributes/load-global-site-attributes.js
+    attributefile: ./product-docs-common/global-attributes.yml
+    enabled: true
 
 output:
   dir: build/site


### PR DESCRIPTION
Currently if #12 is merged, builds using playbooks without the `page-project-data` attribute defined will fail with the error below. This PR enables access to the attribute globally.

```
FATAL (antora): Cannot read properties of undefined (reading 'find') in UI template partials/breadcrumbs.hbs
    Cause: Error
    d')
```