### PR TITLE
docs: fix K3k logo home link

### DIFF
--- a/k3k-community-style/supplemental-files/partials/header-content.hbs
+++ b/k3k-community-style/supplemental-files/partials/header-content.hbs
@@ -2,7 +2,7 @@
   <nav class="navbar">
     <div class="navbar-brand">
       <div class="navbar-item">
-        <a class=" navbar-logo" href="https://docs.k3k.io/" aria-label="K3k Documentation Home"><img class="logo"
+        <a class=" navbar-logo" href="https://rancher.github.io/k3k-product-docs/k3k/latest/en/introduction.html" aria-label="K3k Documentation Home"><img class="logo"
             src="{{uiRootPath}}/img/logo-horizontal-positive-k3k.svg" alt="K3k logo"/></a>
       </div>
 {{#if page.attributes.draft-preview-only}}


### PR DESCRIPTION
## Summary

- Fix the K3k logo link in the documentation header.
- Point the logo to the live GitHub Pages documentation page instead of the nonexistent `https://docs.k3k.io/` URL.

## Verification

- `git diff --check`
- `npm ci && make community-local`
- Confirmed rendered pages contain `https://rancher.github.io/k3k-product-docs/k3k/latest/en/introduction.html`
- Confirmed rendered pages no longer contain `https://docs.k3k.io/`

Fixes #172
