### PR TITLE
Add HCP mode documentation (`v1.2.0`)

### DIFF
--- a/versions/v1.2.0/modules/en/nav.adoc
+++ b/versions/v1.2.0/modules/en/nav.adoc
@@ -17,6 +17,7 @@ endif::[]
 
 * How-tos for User
 ** xref:how-tos-for-user/create-virtual-clusters.adoc[Creating a Virtual Cluster]
+** xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster]
 ** xref:how-tos-for-user/expose-workloads.adoc[Exposing workloads outside a Virtual Cluster]
 ** xref:how-tos-for-user/addons.adoc[Addons]
 

--- a/versions/v1.2.0/modules/en/pages/architecture.adoc
+++ b/versions/v1.2.0/modules/en/pages/architecture.adoc
@@ -81,7 +81,10 @@ Currently, security in virtual  mode has a risk of privilege escalation as the s
 
 == HCP Mode
 
-NOTE: HCP mode is *experimental* in {product-name} v1.2.0.
+[NOTE] 
+====
+HCP mode is *experimental* in {product-name} v1.2.0.
+====
 
 The `hcp` (Hosted Control Plane) mode runs an agentless K3s control plane (apiserver, scheduler, controller-manager) as pods inside the host cluster, but unlike `virtual` mode it does *not* provision any worker pods. Worker nodes live outside the host cluster -- on bare metal, virtual machines, or edge devices that you manage -- and join the virtual cluster using the standard K3s installer (`curl -sfL https://get.k3s.io | K3S_URL=... K3S_TOKEN=... sh -`).
 

--- a/versions/v1.2.0/modules/en/pages/architecture.adoc
+++ b/versions/v1.2.0/modules/en/pages/architecture.adoc
@@ -5,9 +5,10 @@
 
 Virtual Clusters are isolated Kubernetes clusters provisioned on a physical cluster. K3k leverages link:https://k3s.io/[K3s] as the control plane of the Kubernetes cluster because of its lightweight footprint.
 
-K3k provides two modes for deploying virtual clusters: 
-- Shared (default) 
+K3k provides three modes for deploying virtual clusters:
+- Shared (default)
 - Virtual
+- HCP (Hosted Control Plane) -- experimental
 
 == Shared Mode
 
@@ -78,6 +79,32 @@ Security in `virtual` mode benefits from the inherent isolation provided by the 
 
 Currently, security in virtual  mode has a risk of privilege escalation as the server pods run with elevated privileges due to the nature of their function, requiring access to system resources.
 
+== HCP Mode
+
+NOTE: HCP mode is *experimental* in {product-name} v1.2.0.
+
+The `hcp` (Hosted Control Plane) mode runs an agentless K3s control plane (apiserver, scheduler, controller-manager) as pods inside the host cluster, but unlike `virtual` mode it does *not* provision any worker pods. Worker nodes live outside the host cluster -- on bare metal, virtual machines, or edge devices that you manage -- and join the virtual cluster using the standard K3s installer (`curl -sfL https://get.k3s.io | K3S_URL=... K3S_TOKEN=... sh -`).
+
+// TODO: add image::architecture/hcp-mode.png[HCP Mode] once the diagram is available
+
+This mode gives you the operational convenience of a K3k-managed control plane combined with real, fully-isolated worker nodes. To make the apiserver reachable from outside the host cluster, an HCP cluster requires an externally reachable endpoint (`spec.expose.nodePort`, `spec.expose.loadBalancer`, or `spec.expose.ingress`) and a non-loopback entry in `spec.tlsSANs`.
+
+=== Networking and Storage
+
+Because the control plane runs in the host cluster but workers live outside it, the apiserver has no direct route to the virtual cluster's pod CIDR. K3k tunnels apiserver egress (used by webhooks, log/exec, and similar features) through the k3s-agent WebSocket connection. The in-cluster apiserver endpoint reconciler is disabled and K3k owns the `default/kubernetes` Endpoints and EndpointSlice in the virtual cluster, pointing them at the externally reachable host:port.
+
+Workers run a standard K3s agent, so the CNI, the container runtime, and the storage available on each worker are those configured at install time on the worker itself -- the host cluster's CNI and storage are not involved.
+
+=== Resource Sharing and Limits
+
+The control plane consumes resources on the host cluster, and standard pod-level limits apply to the K3s server pods. Workloads scheduled by the virtual cluster consume resources on the *external* worker nodes, completely outside the host cluster's quota and limit accounting.
+
+=== Isolation and Security
+
+HCP mode provides strong workload isolation by construction: tenant workloads never run on the host cluster. The control plane pods still run in the host cluster, but no Virtual Kubelet or k3s-agent surface is exposed for those tenants on the host.
+
+Because external workers join over the network, the security of an HCP cluster depends on the reachability and authentication of the apiserver endpoint. The join token is stored as a Secret in the virtual cluster's namespace and is not embedded in CLI output; treat it as a credential.
+
 == K3k Components
 
 K3k consists of two main components:
@@ -106,22 +133,25 @@ For a deep dive into what VirtualClusterPolicy can do, along with more examples,
 
 == Comparison and Trade-offs
 
-K3k offers two distinct modes for deploying virtual clusters: `shared` and `virtual`. Each mode has its own strengths and weaknesses, and the best choice depends on the specific needs and priorities of the user. Here's a comparison to help you make an informed decision:
+K3k offers three distinct modes for deploying virtual clusters: `shared`, `virtual`, and `hcp`. Each mode has its own strengths and weaknesses, and the best choice depends on the specific needs and priorities of the user. Here's a comparison to help you make an informed decision:
 
 |===
-| Feature | Shared Mode | Virtual Mode
+| Feature | Shared Mode | Virtual Mode | HCP Mode
 
 | *Architecture*
 | Agentless K3s server with Virtual Kubelet
 | Full K3s cluster (server and agents) as pods
+| Agentless K3s control plane in the host cluster + user-supplied external workers
 
 | *Isolation*
 | Network Policies
 | Dedicated control plane and worker nodes as pods
+| Dedicated control plane pods + workers fully outside the host cluster
 
 | *Resource Sharing*
 | Dynamic, namespace-level ResourceQuotas
 | Resource limits on virtual cluster pods
+| Control plane uses host cluster resources; workload resources come from external nodes
 
 | *Networking*
 | Host cluster's CNI
@@ -130,18 +160,24 @@ Host cluster's Ingress Controller (option)
 | Virtual cluster's own CNI
 +
 Virtual cluster's own Ingress Controller
+| Worker node's own CNI
++
+External apiserver endpoint via NodePort/LoadBalancer/Ingress
 
 | *Storage*
 | Host cluster's storage
 | Bring your own storage provider
+| Storage configured on the external worker nodes
 
 | *Security*
 | Pod Security Admission (PSA), Network Policies
 | Inherent isolation, PSA, Network Policies
+| Strong workload isolation (tenant workloads never run on the host); apiserver exposed externally
 
 | *Performance*
 | Smaller footprint, more efficient due to running directly on the host
 | Higher overhead due to running full K3s clusters
+| Low host-cluster footprint (control plane only); worker performance is native
 |===
 
 *Trade-offs:*
@@ -149,5 +185,7 @@ Virtual cluster's own Ingress Controller
 * *Isolation vs. Overhead:* The `shared` mode has lower overhead but weaker isolation, while the `virtual` mode provides stronger isolation but potentially higher overhead due to running full K3s clusters.
 
 * *Resource Sharing:* The `shared` mode offers dynamic resource sharing within a namespace, which can be efficient but less predictable. The `virtual` mode provides dedicated resources to each virtual cluster, offering more control but requiring careful planning.
+
+* *Managed control plane with real workers:* The `hcp` mode is the right choice when you need a real (non-virtualized) worker fleet -- for example bare-metal, edge, or VM-based workers -- but want K3k to manage the control plane lifecycle for you. It requires an externally reachable apiserver endpoint and is currently experimental.
 
 For more information on how to choose the right mode, see xref:./how-tos-for-admin/choose-mode.adoc[Choose Mode].

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-admin/choose-mode.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-admin/choose-mode.adoc
@@ -81,7 +81,10 @@ _"I'm testing a new admission controller and policy engine before rolling it out
 
 == HCP Mode
 
-NOTE: HCP mode is *experimental* in {product-name} v1.2.0.
+[NOTE]
+====
+HCP mode is *experimental* in {product-name} v1.2.0.
+====
 
 *Best for:*
 
@@ -89,7 +92,7 @@ NOTE: HCP mode is *experimental* in {product-name} v1.2.0.
 * Edge and IoT scenarios where workers run outside the host data center
 * Evaluating workloads on dedicated bare-metal or VM hardware while keeping the apiserver centrally managed
 
-In *HCP mode*, K3k runs an agentless K3s control plane inside the host cluster, and you supply the worker nodes. External workers join the cluster using the standard K3s installer script. The apiserver must be reachable from your worker network via `nodePort`, `loadBalancer`, or `ingress`. More details on the link:./../architecture.adoc#_hcp_mode[architecture] and the step-by-step xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster] guide.
+In *HCP mode*, K3k runs an agentless K3s control plane inside the host cluster, and you supply the worker nodes. External workers join the cluster using the standard K3s installer script. The apiserver must be reachable from your worker network via `nodePort`, `loadBalancer`, or `ingress`. For more information, see xref:./../architecture.adoc#_hcp_mode[architecture] and the step-by-step xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster] guide.
 
 === Use Cases by Persona
 

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-admin/choose-mode.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-admin/choose-mode.adoc
@@ -1,9 +1,9 @@
-= How to Choose Between Shared and Virtual Mode
+= How to Choose Between Shared, Virtual, and HCP Mode
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-09-16
+:revdate: 2026-06-17
 :page-revdate: {revdate}
 
-This guide helps you choose the right mode for your virtual cluster: *Shared* or *Virtual*. 
+This guide helps you choose the right mode for your virtual cluster: *Shared*, *Virtual*, or *HCP* (Hosted Control Plane).
 
 If you are unsure, start with *Shared mode* - it is the default and fits most common scenarios.
 
@@ -78,6 +78,35 @@ _"I'm evaluating a new CNI that needs full control of the cluster's networking."
 
 _"I'm testing a new admission controller and policy engine before rolling it out cluster-wide."_ +
 → Use *Virtual mode*, if you need to test cluster-wide policies, custom admission flow, or advanced extensions with full control.
+
+== HCP Mode
+
+NOTE: HCP mode is *experimental* in {product-name} v1.2.0.
+
+*Best for:*
+
+* Users who want K3k to manage the control plane lifecycle but need *real, external* worker nodes
+* Edge and IoT scenarios where workers run outside the host data center
+* Evaluating workloads on dedicated bare-metal or VM hardware while keeping the apiserver centrally managed
+
+In *HCP mode*, K3k runs an agentless K3s control plane inside the host cluster, and you supply the worker nodes. External workers join the cluster using the standard K3s installer script. The apiserver must be reachable from your worker network via `nodePort`, `loadBalancer`, or `ingress`. More details on the link:./../architecture.adoc#_hcp_mode[architecture] and the step-by-step xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster] guide.
+
+=== Use Cases by Persona
+
+==== Platform Admin
+
+_"I want K3k to manage the control plane lifecycle for me, but I need real worker nodes that aren't part of the host cluster."_ +
+→ Use *HCP mode*. The control plane runs in the host cluster, while workers stay under your direct control.
+
+==== Edge / IoT Operator
+
+_"I want a managed control plane in my central cluster, with workers running at the edge."_ +
+→ Use *HCP mode*. Edge workers join over the network and run real workloads on local hardware.
+
+==== Developer
+
+_"I need to test workloads on dedicated bare-metal or VM nodes that aren't part of the host cluster."_ +
+→ Use *HCP mode*. You get a managed control plane without losing access to real-hardware features on the workers.
 
 == Additional information
 

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-admin/choose-mode.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-admin/choose-mode.adoc
@@ -92,7 +92,7 @@ HCP mode is *experimental* in {product-name} v1.2.0.
 * Edge and IoT scenarios where workers run outside the host data center
 * Evaluating workloads on dedicated bare-metal or VM hardware while keeping the apiserver centrally managed
 
-In *HCP mode*, K3k runs an agentless K3s control plane inside the host cluster, and you supply the worker nodes. External workers join the cluster using the standard K3s installer script. The apiserver must be reachable from your worker network via `nodePort`, `loadBalancer`, or `ingress`. For more information, see xref:./../architecture.adoc#_hcp_mode[architecture] and the step-by-step xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster] guide.
+In *HCP mode*, K3k runs an agentless K3s control plane inside the host cluster, and you supply the worker nodes. External workers join the cluster using the standard K3s installer script. The apiserver must be reachable from your worker network via `nodePort`, `loadBalancer`, or `ingress`. For more information, see xref:/architecture.adoc#_hcp_mode[architecture] and the step-by-step xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster] guide.
 
 === Use Cases by Persona
 

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-hcp-virtual-cluster.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-hcp-virtual-cluster.adoc
@@ -56,7 +56,7 @@ NOTE: `agents` is not used in HCP mode -- worker nodes are external and join via
 ----
 k3kcli cluster create \
   --mode hcp \
-  --tls-san <externally-reachable-node-ip-or-dns> \
+  --tls-sans <externally-reachable-node-ip-or-dns> \
   --expose-node-port \
   hcp-server
 ----

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-hcp-virtual-cluster.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-hcp-virtual-cluster.adoc
@@ -1,0 +1,120 @@
+= How to: Create an HCP (Hosted Control Plane) Virtual Cluster
+:revdate: 2026-07-07
+:page-revdate: {revdate}
+
+In *HCP* (Hosted Control Plane) mode, K3k runs an agentless K3s control plane inside the host cluster, while you provide your own external worker nodes that join the cluster using the standard K3s installer script.
+
+This is different from `shared` and `virtual` modes:
+
+* In *shared* mode, workloads run on the host cluster through the Virtual Kubelet.
+* In *virtual* mode, both the control plane and worker nodes run as pods inside the host cluster.
+* In *hcp* mode, only the control plane runs inside the host cluster -- worker nodes live outside it, on machines that you manage.
+
+See xref:../architecture.adoc#_hcp_mode[Architecture: HCP Mode] for a deeper explanation, and xref:../how-tos-for-admin/choose-mode.adoc[Choosing a Mode] for guidance on when to pick HCP.
+
+[WARNING]
+====
+HCP mode is *experimental* in {product-name} v1.2.0. The `k3kcli` prints a warning when this mode is used. The API and behavior may change before HCP is declared stable.
+====
+
+== Prerequisites
+
+* A K3k controller installed on the host cluster (see xref:../quickstart.adoc[Quick Start]).
+* An *externally reachable endpoint* for the virtual cluster's apiserver, exposed via `nodePort`, `loadBalancer`, or `ingress`. Without one, the apiserver is only reachable from inside the host cluster and external workers won't be able to join.
+* One or more external Linux machines that can reach that endpoint over the network. They need `curl` and `systemd`, the same as a standard K3s installation.
+* Each external worker must have a unique hostname and a unique routable IP. Workers behind NAT that share the same address will register as a single node.
+
+== Step 1: Create the HCP cluster
+
+=== CRD Method
+
+[,yaml]
+----
+apiVersion: k3k.io/v1beta1
+kind: Cluster
+metadata:
+  name: hcp-server
+spec:
+  mode: hcp
+  tlsSANs:
+    - "<externally-reachable-node-ip-or-dns>"
+  servers: 1
+  version: v1.33.1-k3s1
+  expose:
+    nodePort: {}
+----
+
+The `tlsSANs` field MUST include at least one non-loopback host (IP or DNS) that your external workers can reach. This entry is added to the apiserver certificate so workers can establish a TLS connection.
+
+One of `expose.nodePort`, `expose.loadBalancer`, or `expose.ingress` is required so the apiserver is reachable from outside the host cluster.
+
+NOTE: `agents` is not used in HCP mode -- worker nodes are external and join via the K3s installer.
+
+=== CLI Method
+
+[,sh]
+----
+k3kcli cluster create \
+  --mode hcp \
+  --tls-san <externally-reachable-node-ip-or-dns> \
+  --expose-node-port \
+  hcp-server
+----
+
+The CLI prints an experimental-mode warning, waits for the cluster to become ready, writes a kubeconfig file, and then prints the instructions you'll need for Steps 2 and 3.
+
+== Step 2: Fetch the join token
+
+The join token is stored in a Secret in the cluster's namespace and is intentionally not embedded in CLI output. Retrieve it with:
+
+[,sh]
+----
+kubectl get secret -n <namespace> <cluster-name>-token -o jsonpath='{.data.token}' | base64 -d
+----
+
+The token secret is named `<cluster-name>-token`. For the example above it would be `hcp-server-token`.
+
+NOTE: `k3kcli cluster create` and `k3kcli kubeconfig generate` print the exact command (with the correct namespace and secret name) for your cluster after the kubeconfig is written.
+
+== Step 3: Join an external worker
+
+On each external worker machine, run:
+
+[,sh]
+----
+curl -sfL https://get.k3s.io | K3S_URL=<serverURL> K3S_TOKEN=<TOKEN> sh -
+----
+
+Substitute:
+
+* `<serverURL>` -- the externally reachable apiserver URL. This is the `server:` value in the generated kubeconfig, and `k3kcli` prints the exact `K3S_URL=...` to use. The port depends on how you exposed the apiserver: the assigned NodePort for `nodePort` (for example `https://203.0.113.10:30001`), or the host on `443` for `loadBalancer`/`ingress`.
+* `<TOKEN>` -- the value retrieved in Step 2.
+
+Repeat on each worker you want to join. Make sure each one has a unique hostname; cloud-init's `set-hostname` or the `--node-name` flag to the K3s installer both work.
+
+== Verify
+
+Generate a kubeconfig for the virtual cluster (or use the one written by `k3kcli cluster create`):
+
+[,sh]
+----
+k3kcli kubeconfig generate --namespace <namespace> --name hcp-server
+export KUBECONFIG=$PWD/hcp-server-kubeconfig.yaml
+kubectl get nodes
+----
+
+Each external worker should appear in the output with status `Ready`.
+
+== Troubleshooting
+
+*No external endpoint configured* +
+If the `Cluster` spec has no `expose.nodePort`, `expose.loadBalancer`, or `expose.ingress`, the apiserver is only reachable from inside the host cluster and external workers can't join. Add one of those `expose` options, and make sure `tlsSANs` includes the external host the workers use.
+
+*Workers can't connect to the apiserver* +
+Confirm that `tlsSANs` contains the exact host the workers use to reach the apiserver, and that the host:port is reachable from the worker network. A TLS handshake error or `x509: certificate is valid for ..., not ...` message in `journalctl -u k3s-agent` indicates a missing SAN.
+
+*Multiple workers register as a single node* +
+The workers are sharing an IP (typically NAT). Give each worker a unique routable IP on a network segment the apiserver can reach back to, and a unique hostname.
+
+*Need a fresh kubeconfig or to re-print the join instructions* +
+Run `k3kcli kubeconfig generate --namespace <namespace> --name <cluster>` again -- the join instructions are re-printed each time.

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-hcp-virtual-cluster.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-hcp-virtual-cluster.adoc
@@ -48,7 +48,10 @@ The `tlsSANs` field MUST include at least one non-loopback host (IP or DNS) that
 
 One of `expose.nodePort`, `expose.loadBalancer`, or `expose.ingress` is required so the apiserver is reachable from outside the host cluster.
 
-NOTE: `agents` is not used in HCP mode -- worker nodes are external and join via the K3s installer.
+[NOTE]
+====
+`agents` is not used in HCP mode -- worker nodes are external and join via the K3s installer.
+====
 
 === CLI Method
 
@@ -57,7 +60,6 @@ NOTE: `agents` is not used in HCP mode -- worker nodes are external and join via
 k3kcli cluster create \
   --mode hcp \
   --tls-sans <externally-reachable-node-ip-or-dns> \
-  --expose-node-port \
   hcp-server
 ----
 
@@ -74,7 +76,10 @@ kubectl get secret -n <namespace> <cluster-name>-token -o jsonpath='{.data.token
 
 The token secret is named `<cluster-name>-token`. For the example above it would be `hcp-server-token`.
 
-NOTE: `k3kcli cluster create` and `k3kcli kubeconfig generate` print the exact command (with the correct namespace and secret name) for your cluster after the kubeconfig is written.
+[NOTE]
+====
+`k3kcli cluster create` and `k3kcli kubeconfig generate` print the exact command (with the correct namespace and secret name) for your cluster after the kubeconfig is written.
+====
 
 == Step 3: Join an external worker
 

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-virtual-clusters.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-virtual-clusters.adoc
@@ -127,6 +127,41 @@ k3kcli cluster create \
   k3kcluster-virtual
 ----
 
+== Use Case: Create a Virtual Cluster in `hcp` (Hosted Control Plane) mode
+
+NOTE: HCP mode is *experimental* in {product-name} v1.2.0.
+
+In `hcp` mode the K3k controller runs an agentless K3s control plane in the host cluster, and you join your own external worker nodes via the standard K3s installer. See the full walkthrough -- including how to fetch the join token and run the installer on workers -- in xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster].
+
+=== CRD Method
+
+[,yaml]
+----
+apiVersion: k3k.io/v1beta1
+kind: Cluster
+metadata:
+  name: k3kcluster-hcp
+spec:
+  mode: hcp
+  tlsSANs:
+    - "<externally-reachable-node-ip-or-dns>"
+  expose:
+    nodePort: {}
+----
+
+An externally reachable endpoint (`expose.nodePort`, `expose.loadBalancer`, or `expose.ingress`) and a non-loopback entry in `tlsSANs` are required so that external workers can reach the apiserver.
+
+=== CLI Method
+
+[,sh]
+----
+k3kcli cluster create \
+  --mode hcp \
+  --tls-san <externally-reachable-node-ip-or-dns> \
+  --expose-node-port \
+  k3kcluster-hcp
+----
+
 == Use Case: Create an Ephemeral Virtual Cluster
 
 === CRD Method

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-virtual-clusters.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-virtual-clusters.adoc
@@ -129,7 +129,10 @@ k3kcli cluster create \
 
 == Use Case: Create a Virtual Cluster in `hcp` (Hosted Control Plane) mode
 
-NOTE: HCP mode is *experimental* in {product-name} v1.2.0.
+[NOTE]
+====
+HCP mode is *experimental* in {product-name} v1.2.0.
+====
 
 In `hcp` mode the K3k controller runs an agentless K3s control plane in the host cluster, and you join your own external worker nodes via the standard K3s installer. See the full walkthrough -- including how to fetch the join token and run the installer on workers -- in xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster].
 

--- a/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-virtual-clusters.adoc
+++ b/versions/v1.2.0/modules/en/pages/how-tos-for-user/create-virtual-clusters.adoc
@@ -157,8 +157,7 @@ An externally reachable endpoint (`expose.nodePort`, `expose.loadBalancer`, or `
 ----
 k3kcli cluster create \
   --mode hcp \
-  --tls-san <externally-reachable-node-ip-or-dns> \
-  --expose-node-port \
+  --tls-sans <externally-reachable-node-ip-or-dns> \
   k3kcluster-hcp
 ----
 

--- a/versions/v1.2.0/modules/en/pages/references/crds.adoc
+++ b/versions/v1.2.0/modules/en/pages/references/crds.adoc
@@ -1,7 +1,7 @@
 [id="k3k-api-reference"]
 :page-languages: [en, de, es, fr, ja, pt, zh]
 = API Reference
-:revdate: "2026-05-05"
+:revdate: "2026-07-07"
 :page-revdate: {revdate}
 :anchor_prefix: k8s-api
 
@@ -134,8 +134,9 @@ _Underlying type:_ _string_
 
 ClusterMode is the possible provisioning mode of a Cluster.
 
-_Validation:_
-- Enum: [shared virtual]
+Supported values: `shared`, `virtual`, `hcp`.
+
+
 
 _Appears In:_
 
@@ -178,8 +179,7 @@ _Appears In:_
 | *`version`* __string__ | Version is the K3s version to use for the virtual nodes. +
 It should follow the K3s versioning convention (e.g., v1.28.2-k3s1). +
 If not specified, the Kubernetes version of the host node will be used. + |  | 
-| *`mode`* __xref:{anchor_prefix}-github-com-rancher-k3k-pkg-apis-k3k-io-v1beta1-clustermode[$$ClusterMode$$]__ | Mode specifies the cluster provisioning mode: "shared" or "virtual". +
-Defaults to "shared". This field is immutable. + | shared | Enum: [shared virtual] +
+| *`mode`* __xref:{anchor_prefix}-github-com-rancher-k3k-pkg-apis-k3k-io-v1beta1-clustermode[$$ClusterMode$$]__ | Mode specifies the cluster provisioning mode. This field is immutable. + | shared | Enum: [shared virtual hcp] +
 
 | *`servers`* __integer__ | Servers specifies the number of K3s pods to run in server (control plane) mode. +
 Must be at least 1. Defaults to 1. + | 1 | 
@@ -382,6 +382,7 @@ _Appears In:_
 | *`ingress`* __xref:{anchor_prefix}-github-com-rancher-k3k-pkg-apis-k3k-io-v1beta1-ingressconfig[$$IngressConfig$$]__ | Ingress specifies options for exposing the API server through an Ingress. + |  | 
 | *`loadBalancer`* __xref:{anchor_prefix}-github-com-rancher-k3k-pkg-apis-k3k-io-v1beta1-loadbalancerconfig[$$LoadBalancerConfig$$]__ | LoadBalancer specifies options for exposing the API server through a LoadBalancer service. + |  | 
 | *`nodePort`* __xref:{anchor_prefix}-github-com-rancher-k3k-pkg-apis-k3k-io-v1beta1-nodeportconfig[$$NodePortConfig$$]__ | NodePort specifies options for exposing the API server through NodePort. + |  | 
+| *`annotations`* __object (keys:string, values:string)__ | Annotations specifies annotations to add to the generated Service. + |  | 
 |===
 
 
@@ -548,8 +549,9 @@ _Underlying type:_ _string_
 
 PodSecurityAdmissionLevel is the policy level applied to the pods in the namespace.
 
-_Validation:_
-- Enum: [privileged baseline restricted]
+Supported values: `privileged`, `baseline`, `restricted`.
+
+
 
 _Appears In:_
 
@@ -613,13 +615,18 @@ Directories within the path are not affected by this setting. +
 This might be in conflict with other options that affect the file +
 mode, like fsGroup, and the result can be other mode bits set. + |  | 
 | *`optional`* __boolean__ | optional field specify whether the Secret or its keys must be defined + |  | 
+| *`name`* __string__ | Name is the name of the secret mount volume that will be used +
+as the name of volume and volume mount for the server or agent pod +
+if empty then the secret name will be used instead. + |  | MaxLength: 63 +
+MinLength: 1 +
+Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` +
+
 | *`mountPath`* __string__ | MountPath is the path within server and agent pods where the +
 secret contents will be mounted. + |  | 
 | *`subPath`* __string__ | SubPath is an optional path within the secret to mount instead of the root. +
 When specified, only the specified key from the secret will be mounted as a file +
 at MountPath, keeping the parent directory writable. + |  | 
-| *`role`* __string__ | Role is the type of the k3k pod that will be used to mount the secret. +
-This can be 'server', 'agent', or 'all' (for both). + |  | Enum: [server agent all] +
+| *`role`* __string__ | Role is the type of the k3k pod that will be used to mount the secret. + |  | Enum: [server agent all] +
 
 |===
 
@@ -791,7 +798,7 @@ to set defaults and constraints (min/max) + |  |
 This includes both node affinity and pod affinity/anti-affinity rules. + |  | 
 | *`defaultAgentAffinity`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#affinity-v1-core[$$Affinity$$]__ | DefaultAgentAffinity specifies the affinity rules applied to agent pods of all clusters in the target Namespace. +
 This includes both node affinity and pod affinity/anti-affinity rules. + |  | 
-| *`allowedMode`* __xref:{anchor_prefix}-github-com-rancher-k3k-pkg-apis-k3k-io-v1beta1-clustermode[$$ClusterMode$$]__ | AllowedMode specifies the allowed cluster provisioning mode. Defaults to "shared". + | shared | Enum: [shared virtual] +
+| *`allowedMode`* __xref:{anchor_prefix}-github-com-rancher-k3k-pkg-apis-k3k-io-v1beta1-clustermode[$$ClusterMode$$]__ | AllowedMode specifies the allowed cluster provisioning mode. + | shared | Enum: [shared virtual hcp] +
 
 | *`disableNetworkPolicy`* __boolean__ | DisableNetworkPolicy indicates whether to disable the creation of a default network policy for cluster isolation. + |  | 
 | *`podSecurityAdmissionLevel`* __xref:{anchor_prefix}-github-com-rancher-k3k-pkg-apis-k3k-io-v1beta1-podsecurityadmissionlevel[$$PodSecurityAdmissionLevel$$]__ | PodSecurityAdmissionLevel specifies the pod security admission level applied to the pods in the namespace. + |  | Enum: [privileged baseline restricted] +

--- a/versions/v1.2.0/modules/en/pages/references/k3kcli.adoc
+++ b/versions/v1.2.0/modules/en/pages/references/k3kcli.adoc
@@ -1,6 +1,6 @@
 = K3k CLI commands 
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: "2026-01-28"
+:revdate: "2026-07-07"
 :page-revdate: {revdate}
 
 == k3kcli
@@ -59,7 +59,7 @@ k3kcli cluster create [command options] NAME
       --kubeconfig-server string      override the kubeconfig server host
       --labels stringArray            Labels to add to the cluster object (e.g. key=value)
       --mirror-host-nodes             Mirror Host Cluster Nodes
-      --mode string                   k3k mode type (shared, virtual) (default "shared")
+      --mode string                   k3k mode type (shared, virtual, hcp) (default "shared")
   -n, --namespace string              namespace of the k3k cluster
       --persistence-type string       persistence mode for the nodes (dynamic, ephemeral) (default "dynamic")
       --policy string                 The policy to create the cluster in
@@ -70,6 +70,7 @@ k3kcli cluster create [command options] NAME
       --storage-class-name string     storage class name for dynamic persistence type
       --storage-request-size string   storage size for dynamic persistence type
       --timeout duration              The timeout for waiting for the cluster to become ready (e.g., 10s, 5m, 1h). (default 3m0s)
+      --tls-sans strings              additional Subject Alternative Names for the cluster server TLS certificate
       --token string                  token of the cluster
       --version string                k3s version
 ----

--- a/versions/v1.2.0/modules/en/pages/release-notes/version-1.2.0.adoc
+++ b/versions/v1.2.0/modules/en/pages/release-notes/version-1.2.0.adoc
@@ -4,6 +4,7 @@
 
 == New Features
 
+* *HCP (Hosted Control Plane) mode (experimental)* -- a new virtual cluster mode that provisions an agentless K3s control plane in the host cluster while letting you join your own external worker nodes via the standard K3s installer. See xref:how-tos-for-user/create-hcp-virtual-cluster.adoc[Creating an HCP Virtual Cluster].
 
 == Core Improvements
 


### PR DESCRIPTION
This PR adds the doc for the new HCP mode (https://github.com/rancher/k3k/pull/876)

It updates also the `k3kcli` and CRDs docs to the latest available.